### PR TITLE
feat(screens): add team listing to `Teams`

### DIFF
--- a/src/components/EmptyList/index.tsx
+++ b/src/components/EmptyList/index.tsx
@@ -1,0 +1,13 @@
+import { Container, Message } from "./styles";
+
+type Props = {
+    message: string;
+};
+
+export default function EmptyList({ message }: Props) {
+    return (
+        <Container>
+            <Message>{message}</Message>
+        </Container>
+    );
+}

--- a/src/components/EmptyList/styles.ts
+++ b/src/components/EmptyList/styles.ts
@@ -1,0 +1,17 @@
+import styled, { css } from "styled-components/native";
+
+export const Container = styled.View`
+    flex: 1;
+    justify-content: center;
+    align-items: center;
+`;
+
+export const Message = styled.Text`
+    text-align: center;
+
+    ${({ theme }) => css`
+        font-size: ${theme.FONT_SIZE.SM}px;
+        color: ${theme.COLORS.GRAY_300};
+        font-family: ${theme.FONT_FAMILY.REGULAR};
+    `};
+`;

--- a/src/components/Highlight/index.tsx
+++ b/src/components/Highlight/index.tsx
@@ -1,0 +1,15 @@
+import { Container, Subtitle, Title } from "./styles";
+
+type Props = {
+    title: string;
+    subtitle: string;
+};
+
+export default function Highlight({ title, subtitle }: Props) {
+    return (
+        <Container>
+            <Title>{title}</Title>
+            <Subtitle>{subtitle}</Subtitle>
+        </Container>
+    );
+}

--- a/src/components/Highlight/styles.ts
+++ b/src/components/Highlight/styles.ts
@@ -1,0 +1,24 @@
+import styled, { css } from "styled-components/native";
+
+export const Container = styled.View`
+    width: 100%;
+    margin: 32px 0;
+`;
+
+export const Title = styled.Text`
+    text-align: center;
+    ${({ theme }) => css`
+        font-size: ${theme.FONT_SIZE.XL}px;
+        color: ${theme.COLORS.WHITE};
+        font-family: ${theme.FONT_FAMILY.BOLD};
+    `};
+`;
+
+export const Subtitle = styled.Text`
+    text-align: center;
+    ${({ theme }) => css`
+        font-size: ${theme.FONT_SIZE.MD}px;
+        color: ${theme.COLORS.GRAY_300};
+        font-family: ${theme.FONT_FAMILY.REGULAR};
+    `};
+`;

--- a/src/components/TeamCard/index.tsx
+++ b/src/components/TeamCard/index.tsx
@@ -1,0 +1,16 @@
+import { TouchableOpacityProps } from "react-native";
+
+import { Container, Icon, Title } from "./styles";
+
+type Props = TouchableOpacityProps & {
+    title: string;
+};
+
+export default function TeamCard({ title, ...rest }: Props) {
+    return (
+        <Container {...rest}>
+            <Icon />
+            <Title>{title}</Title>
+        </Container>
+    );
+}

--- a/src/components/TeamCard/styles.ts
+++ b/src/components/TeamCard/styles.ts
@@ -1,0 +1,33 @@
+import styled, { css } from "styled-components/native";
+import { TouchableOpacity } from "react-native";
+import { UsersThree } from "phosphor-react-native";
+
+export const Container = styled(TouchableOpacity)`
+    width: 100%;
+    height: 90px;
+
+    background-color: ${(props) => props.theme.COLORS.GRAY_500};
+    border-radius: 6px;
+
+    flex-direction: row;
+    align-items: center;
+
+    padding: 24px;
+    margin-bottom: 12px;
+`;
+
+export const Title = styled.Text`
+    ${({ theme }) => css`
+        font-size: ${theme.FONT_SIZE.MD}px;
+        color: ${theme.COLORS.GRAY_200};
+        font-family: ${theme.FONT_FAMILY.REGULAR};
+    `};
+`;
+
+export const Icon = styled(UsersThree).attrs((props) => ({
+    size: 32,
+    color: props.theme.COLORS.BLUE_700,
+    weight: "fill",
+}))`
+    margin-right: 20px;
+`;

--- a/src/screens/Teams/index.tsx
+++ b/src/screens/Teams/index.tsx
@@ -1,11 +1,16 @@
 import { Container } from "./styles";
 
 import Header from "@components/Header";
+import Highlight from "@components/Highlight";
 
 export default function Teams() {
     return (
         <Container>
             <Header showBackButton />
+            <Highlight
+                title="Teams"
+                subtitle="Play with your team"
+            />
         </Container>
     );
 }

--- a/src/screens/Teams/index.tsx
+++ b/src/screens/Teams/index.tsx
@@ -1,15 +1,33 @@
+import { useState } from "react";
+import { FlatList } from "react-native";
+
 import { Container } from "./styles";
 
 import Header from "@components/Header";
 import Highlight from "@components/Highlight";
+import TeamCard from "@components/TeamCard";
+import EmptyList from "@components/EmptyList";
 
 export default function Teams() {
+    const [teams, setTeams] = useState<string[]>(["Team 1", "Team 2"]);
+
     return (
         <Container>
             <Header showBackButton />
+
             <Highlight
                 title="Teams"
                 subtitle="Play with your team"
+            />
+
+            <FlatList
+                data={teams}
+                keyExtractor={(item) => item}
+                renderItem={({ item }) => <TeamCard title={item} />}
+                contentContainerStyle={teams.length === 0 && { flex: 1 }}
+                ListEmptyComponent={() => (
+                    <EmptyList message="👀 What about creating your first team?" />
+                )}
             />
         </Container>
     );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,9 @@
       ],
       "@utils/*": [
         "./src/utils/*"
+      ],
+      "@dtos/*": [
+        "./src/dtos/*"
       ]
     }
   }


### PR DESCRIPTION
# feat(screens): add team listing to `Teams`

This PR creates two new components: `TeamCard` and `EmptyList`. This PR adds those components to the `Teams` screen to create the team list.

## PR Dependencies

-   [x] None
